### PR TITLE
use bash in user path

### DIFF
--- a/macos-guest-virtualbox.sh
+++ b/macos-guest-virtualbox.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Push-button installer of macOS on VirtualBox
 # (c) myspaghetti, licensed under GPL2.0 or higher
 # url: https://github.com/myspaghetti/macos-virtualbox


### PR DESCRIPTION
by changing the path used in shebang, this will make the script more portable. On MacOS Host, for example, installing a newer version of bash is easiest with `brew install bash`. This will install the newer bash to `/usr/local/bin/bash`. By using `/usr/bin/env bash`, the newer bash will automatically be used based on the user's path, instead of having to change the hard-coded path.