### PR TITLE
fix syntax error due to stray `then`

### DIFF
--- a/macos-guest-virtualbox.sh
+++ b/macos-guest-virtualbox.sh
@@ -826,7 +826,7 @@ if [[ -n $(
     while [[ -n $(
         2>&1 VBoxManage storageattach "${vm_name}" --storagectl SATA --port 3 --medium none >/dev/null
         2>&1 VBoxManage closemedium "${macOS_release_name}_BaseSystem.${storage_format}" >/dev/null
-        ) ]]; then do
+        ) ]]; do
         animated_please_wait 10
     done
 fi


### PR DESCRIPTION
Otherwise, this error is emitted:

```
$ bash ./macos-guest-virtualbox.sh 
./macos-guest-virtualbox.sh: line 829: syntax error near unexpected token `then'
./macos-guest-virtualbox.sh: line 829: `        ) ]]; then do'
$ bash --version 
GNU bash, version 5.0.17(1)-release (x86_64-apple-darwin19.4.0)
Copyright (C) 2019 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```