### PR TITLE
Add '"${macOS_release_name}_"*".viso"' to list of temporary files that are safe to delete

### DIFF
--- a/macos-guest-virtualbox.sh
+++ b/macos-guest-virtualbox.sh
@@ -999,6 +999,7 @@ else
                      "${macOS_release_name}_BaseSystem"*
                      "${macOS_release_name}_Install"*
                      "${macOS_release_name}_bootable_installer"*
+                     "${macOS_release_name}_"*".viso"
                      "${vm_name}_"*".png"
                      "${vm_name}_"*".bin"
                      "${vm_name}_"*".txt"


### PR DESCRIPTION
This PR adds '"${macOS_release_name}_"*".viso"' to list of temporary files that are safe to delete
