### PR TITLE
Few critical fixes

### DIFF
--- a/macos-guest-virtualbox.sh
+++ b/macos-guest-virtualbox.sh
@@ -642,7 +642,7 @@ print_dimly "stage: configure_vm"
 VBoxManage modifyvm "${vm_name}" --cpus "${cpu_count}" --memory "${memory_size}" \
  --vram "${gpu_vram}" --pae on --boot1 none --boot2 none --boot3 none \
  --boot4 none --firmware efi --rtcuseutc on --chipset ich9 ${extension_pack_usb3_support} \
- --mouse usbtablet --keyboard usb --audiocontroller hda --audiocodec stac9221
+ --mouse usbtablet --keyboard usb --audiocontroller hda --audiocodec stac9221 --cpu-profile "Intel Xeon X5482 3.20GHz"
 
 VBoxManage setextradata "${vm_name}" \
  "VBoxInternal2/EfiGraphicsResolution" "${resolution}"

--- a/macos-guest-virtualbox.sh
+++ b/macos-guest-virtualbox.sh
@@ -212,17 +212,17 @@ fi
 # VirtualBox in ${PATH}
 # Cygwin
 if [[ -n "$(cygcheck -V 2>/dev/null)" ]]; then
-    if [[ -n "$(cmd.exe /d /s /c call VBoxManage.exe -v 2>/dev/null)" ]]; then
+    if [[ -n "$(cmd.exe /d/s/c call VBoxManage.exe -v 2>/dev/null)" ]]; then
         function VBoxManage() {
-            cmd.exe /d /s /c call VBoxManage.exe "$@"
+            cmd.exe /d/s/c call VBoxManage.exe "$@"
         }
     else
         cmd_path_VBoxManage='C:\Program Files\Oracle\VirtualBox\VBoxManage.exe'
         echo "Can't find VBoxManage in PATH variable,"
         echo "checking ${cmd_path_VBoxManage}"
-        if [[ -n "$(cmd.exe /d /s /c call "${cmd_path_VBoxManage}" -v 2>/dev/null)" ]]; then
+        if [[ -n "$(cmd.exe /d/s/c call "${cmd_path_VBoxManage}" -v 2>/dev/null)" ]]; then
             function VBoxManage() {
-                cmd.exe /d /s /c call "${cmd_path_VBoxManage}" "$@"
+                cmd.exe /d/s/c call "${cmd_path_VBoxManage}" "$@"
             }
             echo "Found VBoxManage"
         else
@@ -1267,7 +1267,7 @@ for wrapper in 1; do
     echo "VBOX_VERSION ${vbox_ver//[$'\r\n']/}"
     macos_ver="$(sw_vers 2>/dev/null)"
     wsl_ver="$(cat /proc/sys/kernel/osrelease 2>/dev/null)"
-    win_ver="$(cmd.exe /d /s /c call ver 2>/dev/null)"
+    win_ver="$(cmd.exe /d/s/c call ver 2>/dev/null)"
     echo "OS VERSION ${macos_ver}${wsl_ver}${win_ver//[$'\r\n']/}"
     echo "################################################################################"
     echo "vbox.log"


### PR DESCRIPTION
1. On my Win10 script starts `cmd /c` fine from `msys` shell, but `cmd /s /c`  starts like it ignores `/c commad`  option, and is waiting for console command input. This make the script impossible to use. But the suggested fix (to remove spaces between `cmd`'s options) works fine.
2. Without explicit processor ID OS fails to boot stuck at "EXITBS:START". 
```
cmd /c ver
Microsoft Windows [Version 10.0.19042.630]
```