### PR TITLE
Fix up dmg2img for some versions (Linux)

### DIFF
--- a/macos-guest-virtualbox.sh
+++ b/macos-guest-virtualbox.sh
@@ -343,7 +343,7 @@ else
 fi
 
 # dmg2img
-if [[ -z "$(dmg2img -d 2>/dev/null)" ]]; then
+if ! dmg2img >/dev/null 2>&1; then
     if [[ -z "$(cygcheck -V 2>/dev/null)" ]]; then
         echo "Please install the package dmg2img."
         exit


### PR DESCRIPTION
The script quickly failed on me with "Please install the package dmg2img." even the program was in my PATH and all.

It's simply because (maybe my specific version) dmg2img emitted its entire help output to stderr.

I think the right way is to simply check the exit code instead of output. Tested on RHEL 8.