### PR TITLE
Clarify instructions for upgrading xxd on systems without vim-8-common.

### DIFF
--- a/macos-guest-virtualbox.sh
+++ b/macos-guest-virtualbox.sh
@@ -245,6 +245,8 @@ if [[ -z "$(xxd -e -p -l 16 /dev/urandom 2>/dev/null)" ]]; then
     echo "Please make sure a version of xxd which supports the -e option is installed."
     echo -e "The -e option should be listed when executing   ${low_contrast_color}xxd --help${default_color}"
     echo "The package vim-common-8 provides a compatible version on most modern distros."
+    echo "If vim-common-8 is not available, you can install from source:"
+    echo "git clone https://github.com/ConorOG/xxd.git && cd xxd && make && cp xxd /usr/bin"
     exit
 fi
 


### PR DESCRIPTION
I'm trying to run this on CentOS 7, which doesn't have `vim-common-8` available as a package. After some hunting around, I realized the "easiest" way to fix the `xxd` issues was to build from the source.

This PR proposes changes to the instructions to help those like me who have little familiarity with Linux to keep moving forward.

I hope this is helpful! Happy for feedback.