### PR TITLE
Use 'env' to find shell

### DIFF
--- a/macos-guest-virtualbox.sh
+++ b/macos-guest-virtualbox.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -i
+#!/usr/bin/env bash -i
 # Push-button installer of macOS on VirtualBox
 # (c) myspaghetti, licensed under GPL2.0 or higher
 # url: https://github.com/myspaghetti/macos-virtualbox


### PR DESCRIPTION
/bin/bash is still v3.  Using env will still use /bin/bash if another (more recent) bash isn't avail.
But if it *is* available, let's use it.

